### PR TITLE
Preserve error message from socket's error event

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -132,7 +132,7 @@ portscanner.checkPortStatus = function(port, options, callback) {
   // Return after the socket has closed
   socket.on('close', function(exception) {
     if(exception && !connectionRefused) 
-      error = exception;
+      error = error || exception;
     else
       error = null;
     callback(error, status)


### PR DESCRIPTION
The `close` event's argument is simply `true` on error, but the `error` event gets a real error object.
